### PR TITLE
Cleaned up the SocketsMonitor class.

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -34,7 +34,7 @@ function Monitor (opt) {
   this.port = opt.port || process.env.DATADOG_PORT;
   this.interval = opt.interval || process.env.MONITOR_INTERVAL;
   this.client = new StatsD(this.host, this.port);
-  this.socketsMonitor = new SocketsMonitor(this, this.prefix, this.interval);
+  this.socketsMonitor = new SocketsMonitor(this);
 }
 
 /**

--- a/lib/sockets-monitor.js
+++ b/lib/sockets-monitor.js
@@ -2,6 +2,7 @@
 
 var child = require('child_process');
 var globalAgent = require('http').globalAgent;
+var exists = require('101/exists');
 
 /**
  * @module monitor-dog:sockets-monitor
@@ -16,52 +17,64 @@ module.exports = SocketsMonitor;
  * - number of **pending** sockets
  * - number of **open** files
  * @class
+ * @param {monitor-dog~Monitor} monitor Monitor to use for reporting data.
+ * @param {string} [prefix='socket'] Prefix for socket events.
+ * @param {number} [interval=monitor.interval] Duration of the reporting
+ *   interval. The SocketsMonitor will setup a `setInterval` and will report
+ *   data every time it fires.
  */
 function SocketsMonitor (monitor, prefix, interval) {
   this.monitor = monitor;
-  this.prefix = prefix;
-  this.interval = interval;
+  this.prefix = prefix || 'socket';
+  this.interval = interval || this.monitor.interval;
 }
 
 /**
- * Start capturing of the sockets stats data.
+ * Begin capturing socket stats.
  */
 SocketsMonitor.prototype.start = function () {
-  if (!this.intervalId) {
-    this.intervalId = setInterval(this._captureSocketStats.bind(this), this.interval);
-  }
+  if (exists(this.intervalId)) { return; }
+  this.intervalId = setInterval(
+    this._captureSocketStats.bind(this),
+    this.interval
+  );
 };
 
 /**
- * Stop capturing of the sockets stats data.
+ * Stop capturing socket stats.
  */
 SocketsMonitor.prototype.stop = function () {
-  if (this.intervalId) {
-    clearInterval(this.intervalId);
-    this.intervalId = null;
+  if (!exists(this.intervalId)) { return; }
+  clearInterval(this.intervalId);
+  this.intervalId = null;
+};
+
+/**
+ * Utility method to report the size of each collection in a given object.
+ * @param {string} suffix Suffix to apply for the gauge name.
+ * @param {object} object Object that contains collections.
+ */
+SocketsMonitor.prototype._gaugeCollections = function (suffix, object) {
+  var pidTag = 'pid:' + process.pid;
+  for (var key in object) {
+    var action = this.prefix + '.' + suffix;
+    var tags = [pidTag, 'target:' + key];
+    this.monitor.gauge(action, object[key].length, 1, tags);
   }
 };
 
 /**
- * Private utility method to gauge `collection`.
+ * Captures and reports socket stats. This method is executed from the context
+ * of the collection interval and should not be explictly called.
  */
-SocketsMonitor.prototype._gaugeCollection = function (suffix, collection) {
-  var pidTag = 'pid:' + process.pid;
-  for (var key in collection) {
-    var action = this.prefix + '.' + suffix;
-    var tags = [pidTag, 'target:' + key];
-    this.monitor.gauge(action, collection[key].length, 1, tags);
-  }
-};
-
 SocketsMonitor.prototype._captureSocketStats = function () {
   var sockets = globalAgent.sockets;
   var requests = globalAgent.requests;
   var pidTag = 'pid:' + process.pid;
   var tags = [pidTag];
 
-  this._gaugeCollection('sockets_open', sockets);
-  this._gaugeCollection('sockets_pending', requests);
+  this._gaugeCollections('open', sockets);
+  this._gaugeCollections('pending', requests);
 
   child.exec('lsof -p ' + process.pid + ' | wc -l', function (err, stdout) {
     if (err) { return; }

--- a/test/sockets-monitor.js
+++ b/test/sockets-monitor.js
@@ -16,6 +16,7 @@ var child = require('child_process');
 
 require('loadenv')('monitor-dog');
 var monitor = require('../index.js');
+var SocketsMonitor = require('../lib/sockets-monitor');
 var dogstatsd = require('./fixtures/dogstatsd');
 
 var ctx = {};
@@ -31,6 +32,32 @@ describe('monitor-dog', function() {
       dogstatsd.restoreAll();
       http.globalAgent = ctx.originalGlobalAgent;
       done();
+    });
+
+    describe('constructor', function() {
+      it('should use given socket prefix', function(done) {
+        var socketMonitor = new SocketsMonitor({}, 'prefix', 1000);
+        expect(socketMonitor.prefix).to.equal('prefix');
+        done();
+      });
+
+      it('should use a default socket prefix if none given', function(done) {
+        var socketMonitor = new SocketsMonitor({}, null, 1000);
+        expect(socketMonitor.prefix).to.equal('socket');
+        done();
+      });
+
+      it('should use given interval', function(done) {
+        var socketMonitor = new SocketsMonitor({}, 'prefix', 1000);
+        expect(socketMonitor.interval).to.equal(1000);
+        done();
+      });
+
+      it('should use default interval if none given', function(done) {
+        var socketMonitor = new SocketsMonitor({ interval: 120 }, 'prefix');
+        expect(socketMonitor.interval).to.equal(120);
+        done();
+      });
     });
 
     it('should not start started monitor', function (done) {


### PR DESCRIPTION
- Cleaned up the source a bit, added missing jsDoc
- Constructor now uses default values when parameters are missing
- Was appending a double monitor prefix, fixed this to have a local prefix for the class (default: `socket`)
- Added additional tests for 100% coverage

cc: @podviaznikov 
