### PR TITLE
Abstract intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,35 @@ request('http://example.com', function(req, res) {
 });
 ```
 
-## Documentation
+## Interval Monitoring
+Creating specialized periodic interval monitors (similar to the sockets monitor)
+is fairly straight-forward. Here's an example of how it is done:
+
+```js
+var monitor = require('monitor-dog');
+var IntervalMonitor = require('monitor-dog/lib/interval-monitor');
+var util = require('util');
+
+/**
+ * 1. Subclass the IntervalMonitor class
+ */
+function MyCustomMonitor = function(monitor, prefix, interval) {
+  IntervalMonitor.call(this, monitor, prefix, interval);
+}
+util.inherits(MyCustomMonitor, IntervalMonitor);
+
+/**
+ * 2. Define your run function to periodically monitor what you wish
+ */
+MyCustomMonitor.prototype.run = function() {
+  // ... Perform custom periodic reporting here using this.monitor
+}
+
+// 3. Instantiate and start your new interval monitor!
+(new MyCustomMonitor(monitor)).start();
+```
+
+## API Documentation
 
 ### .set, .increment, .decrement, .histogram, .gauge
 
@@ -86,10 +114,9 @@ delayedTimer.start();
 delayedTimer.stop();
 ```
 
-### .startSocketsMonitor()
+### .startSocketsMonitor(), .stopSocketsMonitor()
 
 Automatically track number of open & pending sockets and open files.
-
 
 ```js
 // start monitoring once you start web server
@@ -98,7 +125,6 @@ monitor.startSocketsMonitor();
 
 // stop monitoring before stopping web server
 monitor.stopSocketsMonitor();
-
 ```
 
 ### .captureStreamEvents()
@@ -106,11 +132,8 @@ monitor.stopSocketsMonitor();
 Capture stream events: `open`, `data`, `error`, `end`.
 
 ```js
-
 monitor.captureStream('some-name', yourStream);
-
 ```
-
 
 ## License
 

--- a/lib/interval-monitor.js
+++ b/lib/interval-monitor.js
@@ -28,7 +28,7 @@ IntervalMonitor.prototype.run = function() {
   throw new Error(
     'IntervalMonitor is abstract; subclasses must override the run() method.'
   );
-}
+};
 
 /**
  * Starts the interval monitor. This method will have no effect if the interval

--- a/lib/interval-monitor.js
+++ b/lib/interval-monitor.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var exists = require('101/exists');
+
+/**
+ * Interval monitoring base class for monitor-dog.
+ * @module monitor-dog:interval-monitor
+ */
+module.exports = IntervalMonitor;
+
+/**
+ * Abstract base class for all types of specialized monitors that report
+ * information periodically over a given interval.
+ * @param {monitor-dog.Monitor} Base monitor class for the interval monitor.
+ * @param {string} prefix Prefix to use for the interval monitor.
+ * @param {number} interval Amount of time between reports, in milliseconds.
+ */
+function IntervalMonitor(monitor, prefix, interval) {
+  this.monitor = monitor;
+  this.prefix = prefix || this.monitor.prefix;
+  this.interval = interval || this.monitor.interval;
+}
+
+/**
+ * Abstract method meant to report statistics periodically.
+ */
+IntervalMonitor.prototype.run = function() {
+  throw new Error(
+    'IntervalMonitor is abstract; subclasses must override the run() method.'
+  );
+}
+
+/**
+ * Starts the interval monitor. This method will have no effect if the interval
+ * monitor has already been started.
+ */
+IntervalMonitor.prototype.start = function () {
+  if (exists(this.intervalId)) { return; }
+  this.intervalId = setInterval(
+    this.run.bind(this),
+    this.interval
+  );
+};
+
+/**
+ * Stops the interval monitor. This method will have no effect if the interval
+ * monitor has not yet been started.
+ */
+IntervalMonitor.prototype.stop = function () {
+  if (!exists(this.intervalId)) { return; }
+  clearInterval(this.intervalId);
+  this.intervalId = null;
+};

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -9,8 +9,8 @@ var isBoolean = require('101/is-boolean');
 var isString = require('101/is-string');
 var isNumber = require('101/is-number');
 var pluck = require('101/pluck');
-var SocketsMonitor = require('./sockets-monitor');
 
+var SocketsMonitor = require('./sockets-monitor');
 
 /**
  * @module monitor-dog:monitor

--- a/lib/sockets-monitor.js
+++ b/lib/sockets-monitor.js
@@ -42,10 +42,11 @@ SocketsMonitor.prototype.run = function () {
   this._gaugeCollections('open', sockets);
   this._gaugeCollections('pending', requests);
 
+  var self = this;
   child.exec('lsof -p ' + process.pid + ' | wc -l', function (err, stdout) {
     if (err) { return; }
-    var action = this.prefix + '.openFiles';
-    this.monitor.gauge(action, parseInt(stdout), 1, tags);
+    var action = self.prefix + '.openFiles';
+    self.monitor.gauge(action, parseInt(stdout), 1, tags);
   }.bind(this));
 };
 

--- a/lib/sockets-monitor.js
+++ b/lib/sockets-monitor.js
@@ -1,13 +1,14 @@
 'use strict';
 
+var util = require('util');
 var child = require('child_process');
 var globalAgent = require('http').globalAgent;
 var exists = require('101/exists');
+var IntervalMonitor = require('./interval-monitor');
 
 /**
  * @module monitor-dog:sockets-monitor
- * @author Anand Kumar Patel
- * @author Anton Podviaznikov
+ * @author Anand Kumar Patel, Anton Podviaznikov, Ryan Sandor Richards
  */
 module.exports = SocketsMonitor;
 
@@ -24,29 +25,28 @@ module.exports = SocketsMonitor;
  *   data every time it fires.
  */
 function SocketsMonitor (monitor, prefix, interval) {
-  this.monitor = monitor;
-  this.prefix = prefix || 'socket';
-  this.interval = interval || this.monitor.interval;
+  IntervalMonitor.call(this, monitor, prefix || 'socket', interval);
 }
+util.inherits(SocketsMonitor, IntervalMonitor);
 
 /**
- * Begin capturing socket stats.
+ * Captures and reports socket stats. This method is executed from the context
+ * of the collection interval and should not be explictly called.
  */
-SocketsMonitor.prototype.start = function () {
-  if (exists(this.intervalId)) { return; }
-  this.intervalId = setInterval(
-    this._captureSocketStats.bind(this),
-    this.interval
-  );
-};
+SocketsMonitor.prototype.run = function () {
+  var sockets = globalAgent.sockets;
+  var requests = globalAgent.requests;
+  var pidTag = 'pid:' + process.pid;
+  var tags = [pidTag];
 
-/**
- * Stop capturing socket stats.
- */
-SocketsMonitor.prototype.stop = function () {
-  if (!exists(this.intervalId)) { return; }
-  clearInterval(this.intervalId);
-  this.intervalId = null;
+  this._gaugeCollections('open', sockets);
+  this._gaugeCollections('pending', requests);
+
+  child.exec('lsof -p ' + process.pid + ' | wc -l', function (err, stdout) {
+    if (err) { return; }
+    var action = this.prefix + '.openFiles';
+    this.monitor.gauge(action, parseInt(stdout), 1, tags);
+  }.bind(this));
 };
 
 /**
@@ -61,24 +61,4 @@ SocketsMonitor.prototype._gaugeCollections = function (suffix, object) {
     var tags = [pidTag, 'target:' + key];
     this.monitor.gauge(action, object[key].length, 1, tags);
   }
-};
-
-/**
- * Captures and reports socket stats. This method is executed from the context
- * of the collection interval and should not be explictly called.
- */
-SocketsMonitor.prototype._captureSocketStats = function () {
-  var sockets = globalAgent.sockets;
-  var requests = globalAgent.requests;
-  var pidTag = 'pid:' + process.pid;
-  var tags = [pidTag];
-
-  this._gaugeCollections('open', sockets);
-  this._gaugeCollections('pending', requests);
-
-  child.exec('lsof -p ' + process.pid + ' | wc -l', function (err, stdout) {
-    if (err) { return; }
-    var action = this.prefix + '.openFiles';
-    this.monitor.gauge(action, parseInt(stdout), 1, tags);
-  }.bind(this));
 };

--- a/test/interval-monitor.js
+++ b/test/interval-monitor.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var before = lab.before;
+var beforeEach = lab.beforeEach;
+var after = lab.after;
+var afterEach = lab.afterEach;
+var Code = require('code');
+var expect = Code.expect;
+var sinon = require('sinon');
+
+require('loadenv')('monitor-dog');
+var monitor = require('../lib/monitor');
+var IntervalMonitor = require('../lib/interval-monitor');
+
+describe('IntervalMonitor', function() {
+  var clock;
+  var intervalMonitor;
+  var defaultInterval = 1337;
+  var defaultPrefix = 'prefix';
+
+  beforeEach(function (done) {
+    clock = sinon.useFakeTimers();
+    intervalMonitor = new IntervalMonitor(
+      monitor,
+      defaultPrefix,
+      defaultInterval
+    );
+    sinon.stub(intervalMonitor, 'run');
+    done();
+  });
+
+  afterEach(function (done) {
+    clock.restore();
+    done();
+  });
+
+  describe('constructor', function() {
+    it('should set the given monitor', function(done) {
+      expect(intervalMonitor.monitor).to.equal(monitor);
+      done();
+    });
+
+    it('should set the given prefix', function(done) {
+      expect(intervalMonitor.prefix).to.equal(defaultPrefix);
+      done();
+    });
+
+    it('should use the monitor prefix if none was given', function(done) {
+      var noPrefix = new IntervalMonitor(monitor);
+      expect(noPrefix.prefix).to.equal(monitor.prefix);
+      done();
+    });
+
+    it('should set the given interval', function(done) {
+      expect(intervalMonitor.interval).to.equal(defaultInterval);
+      done();
+    });
+
+    it('should set the monitor interval if none was given', function(done) {
+      var noInterval = new IntervalMonitor(monitor);
+      expect(noInterval.interval).to.equal(monitor.interval);
+      done();
+    });
+  });
+
+  describe('.run()', function() {
+    it('should be abstract and throw an error if called', function(done) {
+      intervalMonitor.run.restore();
+      expect(intervalMonitor.run).throws();
+      done();
+    });
+  });
+
+  describe('.start()', function() {
+    it('should start the correct "run" interval', function(done) {
+      intervalMonitor.start();
+      clock.tick(defaultInterval);
+      expect(intervalMonitor.run.calledOnce).to.be.true();
+      done();
+    });
+
+    it('should not start the interval multiple times', function(done) {
+      intervalMonitor.start();
+      intervalMonitor.start();
+      intervalMonitor.start();
+      clock.tick(defaultInterval);
+      expect(intervalMonitor.run.calledOnce).to.be.true();
+      done();
+    });
+  });
+
+  describe('.stop()', function() {
+    it('should stop the "run" interval', function(done) {
+      intervalMonitor.start();
+      intervalMonitor.stop();
+      clock.tick(defaultInterval);
+      expect(intervalMonitor.run.callCount).to.equal(0);
+      done();
+    });
+
+    it('should not attempt to stop the interval twice', function(done) {
+      intervalMonitor.start();
+      try {
+        intervalMonitor.stop();
+        intervalMonitor.stop();
+      }
+      catch (e) {
+        return done(e);
+      }
+      done();
+    });
+  });
+});

--- a/test/sockets-monitor.js
+++ b/test/sockets-monitor.js
@@ -46,51 +46,6 @@ describe('monitor-dog', function() {
         expect(socketMonitor.prefix).to.equal('socket');
         done();
       });
-
-      it('should use given interval', function(done) {
-        var socketMonitor = new SocketsMonitor({}, 'prefix', 1000);
-        expect(socketMonitor.interval).to.equal(1000);
-        done();
-      });
-
-      it('should use default interval if none given', function(done) {
-        var socketMonitor = new SocketsMonitor({ interval: 120 }, 'prefix');
-        expect(socketMonitor.interval).to.equal(120);
-        done();
-      });
-    });
-
-    it('should not start started monitor', function (done) {
-      var custom = monitor.createMonitor({interval: 50, prefix: 'git'});
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      custom.startSocketsMonitor();
-      var oldInterval = custom.socketsMonitor.intervalId;
-      expect(oldInterval).to.exist();
-      custom.startSocketsMonitor();
-      expect(oldInterval).to.equal(custom.socketsMonitor.intervalId);
-      done();
-    });
-
-    it('should stop monitor', function (done) {
-      var custom = monitor.createMonitor({interval: 50, prefix: 'git'});
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      custom.startSocketsMonitor();
-      expect(custom.socketsMonitor.intervalId).to.exist();
-      custom.stopSocketsMonitor();
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      done();
-    });
-
-    it('should not stop stopped monitor', function (done) {
-      var custom = monitor.createMonitor({interval: 50, prefix: 'git'});
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      custom.startSocketsMonitor();
-      expect(custom.socketsMonitor.intervalId).to.exist();
-      custom.stopSocketsMonitor();
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      custom.stopSocketsMonitor();
-      expect(custom.socketsMonitor.intervalId).to.not.exist();
-      done();
     });
 
     it('should start monitor and report open files data & sockets info', function (done) {


### PR DESCRIPTION
This introduces an abstract class named `IntervalMonitor` that lets users define their own interval monitors without having to manage intervals, starting, stopping, etc. Furthermore the `SocketsMonitor` class now inherits from the `IntervalMonitor`.
